### PR TITLE
chore: ensure seamless cask migration for indev users

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+    "indev": "intility/tap/indev"
+}


### PR DESCRIPTION
This PR adds a tap migration reference to ensure a seamless migration from formula to cask when indev users run `brew upgrade`